### PR TITLE
Separate browser code

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Integration tests](https://github.com/starmode-base/neon-testing/actions/workflows/test.yml/badge.svg)](https://github.com/starmode-base/neon-testing/actions/workflows/test.yml)
 [![npm version](https://img.shields.io/npm/v/neon-testing)](https://www.npmjs.com/package/neon-testing)
 [![GitHub release](https://img.shields.io/github/v/release/starmode-base/neon-testing)](https://github.com/starmode-base/neon-testing/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue)](https://opensource.org/licenses/MIT)
 
 A [Vitest](https://vitest.dev/) utility for seamless integration tests with [Neon Postgres](https://neon.com/). <!-- A [STΛR MODΞ](https://starmode.dev) open-source project. -->
 
@@ -82,7 +83,7 @@ First, add the Vite plugin to clear any existing `DATABASE_URL` environment vari
 ```ts
 // vitest.config.ts
 import { defineConfig } from "vitest/config";
-import { neonTesting } from "neon-testing/utils";
+import { neonTesting } from "neon-testing/vite";
 
 export default defineConfig({
   plugins: [neonTesting()],

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Integration tests](https://github.com/starmode-base/neon-testing/actions/workflows/test.yml/badge.svg)](https://github.com/starmode-base/neon-testing/actions/workflows/test.yml)
 [![npm version](https://img.shields.io/npm/v/neon-testing)](https://www.npmjs.com/package/neon-testing)
 [![GitHub release](https://img.shields.io/github/v/release/starmode-base/neon-testing)](https://github.com/starmode-base/neon-testing/releases)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue)](LICENSE)
 
 A [Vitest](https://vitest.dev/) utility for seamless integration tests with [Neon Postgres](https://neon.com/). <!-- A [STΛR MODΞ](https://starmode.dev) open-source project. -->
 

--- a/browser-empty.ts
+++ b/browser-empty.ts
@@ -1,0 +1,3 @@
+export function neonTesting() {
+  throw new Error("neon-testing/vite is Node-only (Vite/Vitest context).");
+}

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
       },
       "devDependencies": {
         "@neondatabase/serverless": "^1.0.1",
-        "dotenv": "^17.2.1",
+        "dotenv": "^17.2.2",
         "drizzle-orm": "^0.44.5",
         "pg": "^8.16.3",
         "postgres": "^3.4.7",
@@ -167,7 +167,7 @@
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
-    "dotenv": ["dotenv@17.2.1", "", {}, "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ=="],
+    "dotenv": ["dotenv@17.2.2", "", {}, "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q=="],
 
     "drizzle-orm": ["drizzle-orm@0.44.5", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-jBe37K7d8ZSKptdKfakQFdeljtu3P2Cbo7tJoJSVZADzIKOBo9IAJPOmMsH2bZl90bZgh8FQlD8BjxXA/zuBkQ=="],
 

--- a/index.ts
+++ b/index.ts
@@ -184,7 +184,7 @@ export function makeNeonTesting(factoryOptions: NeonTestingOptions) {
 
     beforeAll(async () => {
       process.env.DATABASE_URL = await withRetry(createBranch, {
-        maxRetries: 5,
+        maxRetries: 8,
         baseDelayMs: 1000,
       });
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "./utils": {
       "types": "./dist/utils.d.ts",
       "import": "./dist/utils.js"
+    },
+    "./vite": {
+      "types": "./dist/vite-plugin.d.ts",
+      "import": "./dist/vite-plugin.js"
     }
   },
   "files": [
@@ -54,5 +58,8 @@
     "typescript": "^5.9.2",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4"
+  },
+  "browser": {
+    "./dist/vite-plugin.js": "./dist/browser-empty.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-testing",
-  "version": "2.1.1",
+  "version": "2.1.2-beta.0",
   "description": "A Vitest utility for seamless integration tests with Neon Postgres",
   "keywords": [
     "neon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon-testing",
-  "version": "2.1.2-beta.0",
+  "version": "2.1.2-beta.1",
   "description": "A Vitest utility for seamless integration tests with Neon Postgres",
   "keywords": [
     "neon",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dist"
   ],
   "scripts": {
+    "dev": "tsc --watch",
     "build": "rm -rf dist && tsc",
     "test": "vitest",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@neondatabase/serverless": "^1.0.1",
-    "dotenv": "^17.2.1",
+    "dotenv": "^17.2.2",
     "drizzle-orm": "^0.44.5",
     "pg": "^8.16.3",
     "postgres": "^3.4.7",

--- a/utils.ts
+++ b/utils.ts
@@ -1,2 +1,7 @@
+import { neonTesting as neonTestingVite } from "./vite-plugin.js";
 export { lazySingleton } from "./singleton.js";
-export { neonTesting } from "./vite-plugin.js";
+
+/**
+ * @deprecated Import the Vite plugin from "neon-testing/vite" instead.
+ */
+export const neonTesting = neonTestingVite;

--- a/utils.ts
+++ b/utils.ts
@@ -2,6 +2,7 @@ import { neonTesting as neonTestingVite } from "./vite-plugin.js";
 export { lazySingleton } from "./singleton.js";
 
 /**
- * @deprecated Import the Vite plugin from "neon-testing/vite" instead.
+ * @deprecated Import the Vite plugin from "neon-testing/vite" instead. This
+ * export will be removed in the next major version.
  */
 export const neonTesting = neonTestingVite;

--- a/vite-plugin.ts
+++ b/vite-plugin.ts
@@ -1,6 +1,9 @@
 import { fileURLToPath } from "node:url";
 import type { Plugin } from "vite";
 
+/**
+ * Neon Testing Vite plugin
+ */
 export function neonTesting(
   options: {
     /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,20 @@
 import { defineConfig } from "vitest/config";
 import dotenv from "dotenv";
 import tsconfigPaths from "vite-tsconfig-paths";
-import { neonTesting } from "./utils";
+import { neonTesting } from "./vite-plugin";
 
 dotenv.config();
 
 export default defineConfig({
   test: {
     testTimeout: 10000,
+    hookTimeout: 20000,
+    poolOptions: {
+      forks: {
+        // Limit to concurrent test files to avoid Neon API rate limiting
+        maxForks: 2,
+      },
+    },
   },
   plugins: [tsconfigPaths(), neonTesting({ debug: false })],
 });


### PR DESCRIPTION
Changes

- The Vite plugin gets a new subpath export `neon-testing/vite`, deprecating `neon-testing/utils`
- Improve browser compatibility with `neon-testing/utils` (deprecated, but for user who has not upgraded their imports)